### PR TITLE
Feature/create panel wrapper

### DIFF
--- a/src/components/cms/page-editor/panels/editor/PanelPageEditor.tsx
+++ b/src/components/cms/page-editor/panels/editor/PanelPageEditor.tsx
@@ -13,7 +13,7 @@ import PanelWrapper from '@components/cms/ui/panel/PanelWrapper'
 
 const PanelPageEditor = () => {
   return (
-    <PanelWrapper>
+    <PanelWrapper borderSide="left">
       <PanelBox>
         <Heading level={5} margin="none">
           Component Editor

--- a/src/components/cms/page-editor/panels/editor/PanelPageEditor.tsx
+++ b/src/components/cms/page-editor/panels/editor/PanelPageEditor.tsx
@@ -1,4 +1,4 @@
-import { Box, FormField, Heading, Text, TextArea, TextInput } from 'grommet'
+import { FormField, Heading, Text, TextArea, TextInput } from 'grommet'
 import PanelBox from '@components/cms/ui/panel/PanelBox'
 import PanelBoxCollapsable from '@components/cms/ui/panel/PanelBoxCollapsible'
 import { Edit, Paint, SettingsOption } from 'grommet-icons'
@@ -9,10 +9,11 @@ import {
   PanelTabTrigger,
 } from '@components/cms/ui/panel/PanelTabs/index'
 import PanelBoxScroll from '@components/cms/ui/panel/PanelBoxScroll'
+import PanelWrapper from '@components/cms/ui/panel/PanelWrapper'
 
 const PanelPageEditor = () => {
   return (
-    <Box width="full">
+    <PanelWrapper>
       <PanelBox>
         <Heading level={5} margin="none">
           Component Editor
@@ -87,7 +88,7 @@ const PanelPageEditor = () => {
           </PanelBox>
         </PanelTabContent>
       </PanelTabs>
-    </Box>
+    </PanelWrapper>
   )
 }
 

--- a/src/components/cms/page-editor/panels/selector/PanelComponentSelector.tsx
+++ b/src/components/cms/page-editor/panels/selector/PanelComponentSelector.tsx
@@ -27,7 +27,7 @@ const ComponentSelectorItem = () => {
 
 const PanelComponentSelector = () => {
   return (
-    <PanelWrapper borderSide="left">
+    <PanelWrapper borderSide="right">
       <PanelBox>
         <Heading level={5} margin="none">
           UI Section Components

--- a/src/components/cms/page-editor/panels/selector/PanelComponentSelector.tsx
+++ b/src/components/cms/page-editor/panels/selector/PanelComponentSelector.tsx
@@ -2,6 +2,7 @@ import { Box, Heading, Text, TextInput } from 'grommet'
 import { Search } from 'grommet-icons'
 import PanelBox from '@components/cms/ui/panel/PanelBox'
 import PanelBoxScroll from '@components/cms/ui/panel/PanelBoxScroll'
+import PanelWrapper from '@components/cms/ui/panel/PanelWrapper'
 
 const ComponentSelectorItem = () => {
   return (
@@ -26,7 +27,7 @@ const ComponentSelectorItem = () => {
 
 const PanelComponentSelector = () => {
   return (
-    <Box>
+    <PanelWrapper borderSide="left">
       <PanelBox>
         <Heading level={5} margin="none">
           UI Section Components
@@ -36,7 +37,7 @@ const PanelComponentSelector = () => {
         </Text>
       </PanelBox>
 
-      <PanelBox borderSide={false}>
+      <PanelBox>
         <TextInput
           icon={<Search />}
           size="small"
@@ -54,7 +55,7 @@ const PanelComponentSelector = () => {
         <ComponentSelectorItem />
         <ComponentSelectorItem />
       </PanelBoxScroll>
-    </Box>
+    </PanelWrapper>
   )
 }
 

--- a/src/components/cms/ui/Header.tsx
+++ b/src/components/cms/ui/Header.tsx
@@ -4,7 +4,7 @@ const Header = () => {
   return (
     <GrommetHeader
       background={'dark-1'}
-      pad="medium"
+      pad={{ horizontal: 'medium', vertical: 'small' }}
       align="center"
       justify="start"
       width="full"

--- a/src/components/cms/ui/panel/PanelBox.tsx
+++ b/src/components/cms/ui/panel/PanelBox.tsx
@@ -16,7 +16,14 @@ const PanelBox = ({
     ? { side: borderSide, color: 'dark-3' }
     : undefined
   return (
-    <Box pad={pad} gap="xsmall" flex="grow" border={borderProp} {...restProps}>
+    <Box
+      pad={pad}
+      gap="xsmall"
+      flex="grow"
+      border={borderProp}
+      width="100%"
+      {...restProps}
+    >
       {children}
     </Box>
   )

--- a/src/components/cms/ui/panel/PanelTabs/index.tsx
+++ b/src/components/cms/ui/panel/PanelTabs/index.tsx
@@ -71,7 +71,7 @@ export const PanelTabList: FC<
   PanelTabListProps & PanelTabListInjectedProps
 > = ({ children, activeValue, setActiveValue }) => {
   return (
-    <PanelBox pad="none">
+    <PanelBox pad="none" flex={false}>
       <Box direction="row">
         {Children.map(children, (child) => {
           if (

--- a/src/components/cms/ui/panel/PanelWrapper.tsx
+++ b/src/components/cms/ui/panel/PanelWrapper.tsx
@@ -1,0 +1,26 @@
+import { Box } from 'grommet'
+
+type PanelWrapperProps = React.ComponentProps<typeof Box> & {
+  children?: React.ReactNode
+  borderSide?: 'top' | 'bottom' | 'left' | 'right'
+}
+
+const PanelWrapper = ({
+  children,
+  borderSide = 'right',
+  ...rest
+}: PanelWrapperProps) => {
+  return (
+    <Box
+      background="dark-1"
+      align="center"
+      justify="start"
+      border={{ side: borderSide, color: 'dark-2' }}
+      {...rest}
+    >
+      {children}
+    </Box>
+  )
+}
+
+export default PanelWrapper

--- a/src/components/cms/ui/panel/PanelWrapper.tsx
+++ b/src/components/cms/ui/panel/PanelWrapper.tsx
@@ -15,6 +15,7 @@ const PanelWrapper = ({
       background="dark-1"
       align="center"
       justify="start"
+      fill
       border={{ side: borderSide, color: 'dark-2' }}
       {...rest}
     >

--- a/src/layouts/DefaultLayout.tsx
+++ b/src/layouts/DefaultLayout.tsx
@@ -1,6 +1,5 @@
 import { Grid, Box } from 'grommet'
 import Header from '@components/cms/ui/Header'
-import Footer from '@components/cms/ui/Footer'
 
 interface DefaultLayoutProps {
   children?: React.ReactNode
@@ -15,16 +14,12 @@ function DefaultLayout({ children }: DefaultLayoutProps) {
       areas={[
         { name: 'header', start: [0, 0], end: [0, 0] },
         { name: 'content', start: [0, 1], end: [0, 1] },
-        { name: 'footer', start: [0, 2], end: [0, 2] },
       ]}
     >
       <Box gridArea="header">
         <Header />
       </Box>
       <Box gridArea="content">{children}</Box>
-      <Box gridArea="footer">
-        <Footer />
-      </Box>
     </Grid>
   )
 }

--- a/src/layouts/EditorLayout.tsx
+++ b/src/layouts/EditorLayout.tsx
@@ -18,13 +18,7 @@ function EditorLayout({ children }: EditorLayoutProps) {
         { name: 'main-right', start: [2, 1], end: [2, 1] },
       ]}
     >
-      <Box
-        gridArea="main-left"
-        background="dark-1"
-        align="center"
-        justify="start"
-        border={{ side: 'right', color: 'dark-2' }}
-      >
+      <Box gridArea="main-left">
         <PanelComponentSelector />
       </Box>
 
@@ -44,13 +38,7 @@ function EditorLayout({ children }: EditorLayoutProps) {
         )}
       </Box>
 
-      <Box
-        gridArea="main-right"
-        background="dark-1"
-        align="center"
-        justify="start"
-        border={{ side: 'left', color: 'dark-2' }}
-      >
+      <Box gridArea="main-right">
         <PanelPageEditor />
       </Box>
     </Grid>


### PR DESCRIPTION
This pull request introduces a new `PanelWrapper` component to standardize the layout and styling of panel containers across the CMS, updates several components to use this new wrapper, and makes minor layout and styling adjustments to improve consistency and maintainability.

<img width="1920" height="959" alt="image" src="https://github.com/user-attachments/assets/f57b4b14-33e8-4415-8288-e57131fda75b" />


### Introduction of `PanelWrapper` Component:
* Added a new `PanelWrapper` component in `src/components/cms/ui/panel/PanelWrapper.tsx` to provide a reusable container with configurable borders and consistent styling. 

### Refactoring to Use `PanelWrapper`:
* Replaced `Box` with `PanelWrapper` in `PanelPageEditor` to wrap the editor panel with consistent styling. 
* Updated `PanelComponentSelector` to use `PanelWrapper` for consistent layout and added a `borderSide` prop for flexibility. 

### Layout and Styling Adjustments:
* Adjusted padding in the `Header` component for better spacing using an object format. (`[src/components/cms/ui/Header.tsxL7-R7](diffhunk://#diff-896cc4404f4ed6a212bbed9a99630a1989b953e27f671224b77a9f13df51b279L7-R7)`)
* Modified `PanelBox` to include a `width="100%"` property for full-width panels and improved readability of props. 
* Updated `PanelTabList` to set `flex={false}` in the `PanelBox` to prevent unintended stretching. 

### Layout Simplification:
* Removed the `Footer` component from `DefaultLayout` and its corresponding grid area, simplifying the layout structure. 
* Simplified the `EditorLayout` by removing inline `Box` styling and delegating it to the `PanelWrapper` used in child components. 