### PR TITLE
Feature/create page canvas

### DIFF
--- a/src/components/cms/page-editor/canvas/PageCanvas.tsx
+++ b/src/components/cms/page-editor/canvas/PageCanvas.tsx
@@ -1,0 +1,11 @@
+import { Box, Text } from 'grommet'
+
+const PageCanvas = () => {
+  return (
+    <Box fill background="white">
+      <Text>Page Canvas Component</Text>
+    </Box>
+  )
+}
+
+export default PageCanvas

--- a/src/components/cms/page-editor/canvas/PageCanvas.tsx
+++ b/src/components/cms/page-editor/canvas/PageCanvas.tsx
@@ -1,9 +1,23 @@
-import { Box, Text } from 'grommet'
+import CardGrid from '@components/site/CardGrid'
+import Footer from '@components/site/Footer'
+import Hero from '@components/site/Hero'
+import InfoText from '@components/site/InfoText'
+import Nav from '@components/site/Nav'
+import { Box } from 'grommet'
 
 const PageCanvas = () => {
   return (
-    <Box fill background="white">
-      <Text>Page Canvas Component</Text>
+    <Box
+      style={{ display: 'block' }}
+      fill
+      background="white"
+      overflow={{ vertical: 'auto', horizontal: 'hidden' }}
+    >
+      <Nav />
+      <Hero />
+      <CardGrid />
+      <InfoText />
+      <Footer />
     </Box>
   )
 }

--- a/src/components/site/CardGrid/index.tsx
+++ b/src/components/site/CardGrid/index.tsx
@@ -1,0 +1,51 @@
+import React from 'react'
+import { Box, Heading } from 'grommet'
+import Card from '../ui/Card'
+
+const cards = [
+  {
+    title: 'Card 1',
+    description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+  },
+  {
+    title: 'Card 2',
+    description: 'Sed do eiusmod tempor incididunt ut labore et dolore.',
+  },
+  {
+    title: 'Card 3',
+    description: 'Ut enim ad minim veniam, quis nostrud exercitation.',
+  },
+]
+
+const CardGrid: React.FC = () => {
+  return (
+    <Box
+      as="section"
+      background="light-2"
+      align="center"
+      pad={{ top: 'large', bottom: 'xlarge', horizontal: 'medium' }}
+    >
+      <Heading
+        level={3}
+        weight="bold"
+        size="xlarge"
+        margin={{ top: 'none', bottom: 'medium' }}
+      >
+        Featured Cards
+      </Heading>
+      <Box
+        direction="row-responsive"
+        gap="medium"
+        fill="horizontal"
+        align="center"
+        justify="center"
+      >
+        {cards.map((card, idx) => (
+          <Card key={idx} title={card.title} description={card.description} />
+        ))}
+      </Box>
+    </Box>
+  )
+}
+
+export default CardGrid

--- a/src/components/site/Footer/index.tsx
+++ b/src/components/site/Footer/index.tsx
@@ -1,0 +1,72 @@
+import React from 'react'
+import { Box, Grid, Text, Anchor, Heading } from 'grommet'
+import { Rocket } from 'lucide-react'
+
+const footerLinks = [
+  {
+    title: 'Company',
+    links: ['About', 'Careers', 'Contact'],
+  },
+  {
+    title: 'Support',
+    links: ['Help Center', 'FAQ'],
+  },
+  {
+    title: 'Legal',
+    links: ['Privacy Policy', 'Terms'],
+  },
+]
+
+const Footer: React.FC = () => (
+  <Box
+    background="#23242a"
+    pad={{ top: 'large', bottom: 'medium', horizontal: 'large' }}
+  >
+    <Grid
+      columns={['auto', 'auto', 'auto', 'auto']}
+      gap="large"
+      align="start"
+      margin={{ bottom: 'large' }}
+      responsive
+    >
+      <Box gap="medium">
+        <Rocket size={32} />
+        <Text weight="bold" size="large" color="white">
+          Site Kit Builder
+        </Text>
+      </Box>
+
+      {footerLinks.map((col) => (
+        <Box key={col.title} gap="xsmall">
+          <Heading
+            level={4}
+            color="white"
+            margin={{ bottom: 'small', top: 'none' }}
+          >
+            {col.title}
+          </Heading>
+          {col.links.map((link) => (
+            <Anchor
+              key={link}
+              href="#"
+              color="white"
+              size="medium"
+              label={link}
+            />
+          ))}
+        </Box>
+      ))}
+    </Grid>
+    <Box
+      border={{ side: 'top', color: 'dark-3' }}
+      pad={{ top: 'small' }}
+      margin={{ top: 'large' }}
+    >
+      <Text color="white" size="small">
+        © 2025 Site Kit Builder. All rights reserved.
+      </Text>
+    </Box>
+  </Box>
+)
+
+export default Footer

--- a/src/components/site/Hero/index.tsx
+++ b/src/components/site/Hero/index.tsx
@@ -1,0 +1,36 @@
+import React from 'react'
+import { Box, Heading, Text, Button } from 'grommet'
+
+interface HeroProps {
+  title?: string
+  description?: string
+  buttonLabel?: string
+  onButtonClick?: () => void
+}
+
+const Hero: React.FC<HeroProps> = ({
+  title = 'Welcome to Site Kit Builder',
+  description = 'Create and customize your website easily with our intuitive tools.',
+  buttonLabel = 'Get Started',
+  onButtonClick,
+}) => (
+  <Box
+    as="section"
+    align="center"
+    justify="center"
+    height="50vh"
+    background={{ color: 'white' }}
+    pad={{ vertical: 'xlarge', horizontal: 'medium' }}
+    gap="medium"
+  >
+    <Heading level={1} color="black" weight="bold" margin="none">
+      {title}
+    </Heading>
+    <Text size="large" color="dark-2" textAlign="center">
+      {description}
+    </Text>
+    <Button primary label={buttonLabel} size="large" onClick={onButtonClick} />
+  </Box>
+)
+
+export default Hero

--- a/src/components/site/InfoText/index.tsx
+++ b/src/components/site/InfoText/index.tsx
@@ -1,0 +1,82 @@
+import React from 'react'
+import { Box, Heading, Text, Image, Anchor } from 'grommet'
+
+const formats = [
+  {
+    label: 'Lorem ipsum dolor',
+    description: 'Sit amet, consectetur adipiscing elit.',
+  },
+  {
+    label: 'Sed do eiusmod',
+    description: 'Tempor incididunt ut labore et dolore magna aliqua.',
+  },
+  {
+    label: 'Ut enim ad minim',
+    description: 'Veniam, quis nostrud exercitation ullamco laboris nisi.',
+  },
+  {
+    label: 'Duis aute irure',
+    description: 'Dolor in reprehenderit in voluptate velit esse.',
+  },
+  {
+    label: 'Excepteur sint occaecat',
+    description: 'Cupidatat non proident, sunt in culpa qui officia.',
+  },
+]
+
+const InfoText: React.FC = () => (
+  <Box
+    as="section"
+    direction="row-responsive"
+    gap="large"
+    align="start"
+    justify="between"
+    pad={{ vertical: 'xlarge', horizontal: 'large' }}
+  >
+    <Box width="60%">
+      <Heading
+        level={2}
+        weight="bold"
+        margin={{ bottom: 'small', top: 'none' }}
+      >
+        Lorem ipsum dolor sit amet
+      </Heading>
+      <Text size="large" margin={{ bottom: 'medium' }}>
+        Consectetur adipiscing elit. Pellentesque euismod, nisi eu consectetur.
+      </Text>
+      <Box as="ul" pad={{ left: 'small' }}>
+        {formats.map((f) => (
+          <Box
+            as="li"
+            direction="row"
+            gap="xsmall"
+            key={f.label}
+            margin={{ bottom: 'xsmall' }}
+          >
+            <Box as="span" color="accent-1" margin={{ top: '4px' }}>
+              &#8226;
+            </Box>
+            <Text>
+              <Text weight="bold">{f.label}:</Text> {f.description}
+            </Text>
+          </Box>
+        ))}
+      </Box>
+      <Text size="xsmall" margin={{ top: 'medium' }}>
+        Lorem ipsum <Anchor href="#" label="dolor sit amet" weight="bold" />,
+        consectetur adipiscing elit. Pellentesque euismod, nisi eu consectetur,
+        facilisis.
+      </Text>
+    </Box>
+    <Box width="340px" height="340px" round overflow="hidden" flex={false}>
+      <Image
+        src="https://picsum.photos/id/42/340/340"
+        fit="cover"
+        style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+        alt="Learning formats preview"
+      />
+    </Box>
+  </Box>
+)
+
+export default InfoText

--- a/src/components/site/InfoText/index.tsx
+++ b/src/components/site/InfoText/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Box, Heading, Text, Image, Anchor } from 'grommet'
+import { Box, Heading, Text, Image } from 'grommet'
 
 const formats = [
   {
@@ -29,8 +29,8 @@ const InfoText: React.FC = () => (
     as="section"
     direction="row-responsive"
     gap="large"
-    align="start"
-    justify="between"
+    align="center"
+    justify="center"
     pad={{ vertical: 'xlarge', horizontal: 'large' }}
   >
     <Box width="60%">
@@ -62,11 +62,6 @@ const InfoText: React.FC = () => (
           </Box>
         ))}
       </Box>
-      <Text size="xsmall" margin={{ top: 'medium' }}>
-        Lorem ipsum <Anchor href="#" label="dolor sit amet" weight="bold" />,
-        consectetur adipiscing elit. Pellentesque euismod, nisi eu consectetur,
-        facilisis.
-      </Text>
     </Box>
     <Box width="340px" height="340px" round overflow="hidden" flex={false}>
       <Image

--- a/src/components/site/Nav/index.tsx
+++ b/src/components/site/Nav/index.tsx
@@ -1,0 +1,56 @@
+import React from 'react'
+import { Box, Nav as GrommetNav } from 'grommet'
+
+interface NavItem {
+  label: string
+  href: string
+}
+
+interface NavProps {
+  items?: NavItem[]
+}
+
+const defaultItems: NavItem[] = [
+  { label: 'Home', href: '/' },
+  { label: 'About', href: '/about' },
+  { label: 'Blog', href: '/blog' },
+  { label: 'Contact', href: '/contact' },
+]
+
+import { Button } from 'grommet'
+import { Rocket } from 'lucide-react'
+
+const Nav: React.FC<NavProps> = ({ items = defaultItems }) => (
+  <Box
+    direction="row"
+    align="center"
+    justify="between"
+    pad={{ vertical: 'small', horizontal: 'large' }}
+    fill="horizontal"
+    background="white"
+    elevation="small"
+    height={{ min: '64px' }}
+    border={{ side: 'bottom', color: 'light-1', size: 'xsmall' }}
+  >
+    <Box width="32px" height="32px" justify="center" align="center">
+      <Rocket />
+    </Box>
+    <Box flex align="center" justify="center">
+      <GrommetNav direction="row" gap="medium">
+        {items.map((item) => (
+          <Button
+            key={item.href}
+            label={item.label}
+            href={item.href}
+            style={{ padding: '8px 16px', borderRadius: '4px' }}
+          />
+        ))}
+      </GrommetNav>
+    </Box>
+    <Box>
+      <Button label="Contact US" primary />
+    </Box>
+  </Box>
+)
+
+export default Nav

--- a/src/components/site/ui/Card/index.tsx
+++ b/src/components/site/ui/Card/index.tsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import {
+  Card as GrommetCard,
+  CardBody,
+  CardFooter,
+  Heading,
+  Text,
+} from 'grommet'
+
+interface CardProps {
+  title: string
+  description: string
+}
+
+const Card: React.FC<CardProps> = ({ title, description }) => (
+  <GrommetCard
+    background="white"
+    elevation="small"
+    pad="small"
+    width="large"
+    height={{ min: '180px' }}
+  >
+    <CardBody>
+      <Heading level={3} margin={{ bottom: 'small', top: 'none' }}>
+        {title}
+      </Heading>
+      <Text>{description}</Text>
+    </CardBody>
+    <CardFooter pad={{ top: 'small' }}>
+      <Text size="small" color="brand">
+        Learn more
+      </Text>
+    </CardFooter>
+  </GrommetCard>
+)
+
+export default Card

--- a/src/layouts/EditorLayout.tsx
+++ b/src/layouts/EditorLayout.tsx
@@ -2,6 +2,7 @@ import { Grid, Box } from 'grommet'
 import PanelPageEditor from '@components/cms/page-editor/panels/editor/PanelPageEditor'
 import ComponentSelector from '@components/cms/page-editor/panels/selector/ComponentSelector'
 import Sidebar from '@components/cms/page-editor/panels/sidebar/Sidebar'
+import PageCanvas from '@components/cms/page-editor/canvas/PageCanvas'
 
 interface EditorLayoutProps {
   children?: React.ReactNode
@@ -39,14 +40,7 @@ function EditorLayout({ children }: EditorLayoutProps) {
         align="center"
         justify="center"
       >
-        {children || (
-          <>
-            <h3 style={{ margin: '0 0 16px 0' }}>Sección 2</h3>
-            <p style={{ margin: 0, textAlign: 'center' }}>
-              Segunda parte de la fila dividida
-            </p>
-          </>
-        )}
+        {children || <PageCanvas />}
       </Box>
 
       <Box gridArea="right-editor">


### PR DESCRIPTION
This pull request introduces a new `PageCanvas` component to serve as the main content area for the page editor and integrates it into the `EditorLayout`. Additionally, it adds several reusable components (`Hero`, `CardGrid`, `InfoText`, `Footer`, `Nav`, and `Card`) to build a structured and visually appealing layout for the `PageCanvas`.

<img width="1920" height="956" alt="image" src="https://github.com/user-attachments/assets/1dfe1334-f909-45fd-bd75-d421d873cfca" />


### Integration of `PageCanvas` into the editor layout:
Replaced placeholder content with the newly created `PageCanvas` component, ensuring it is used as the default content area when no children are provided.

### Creation of reusable components for `PageCanvas`:
Added the `PageCanvas` component, which organizes the layout using reusable components such as `Nav`, `Hero`, `CardGrid`, `InfoText`, and `Footer`.

Implemented the `Nav` component for navigation, featuring default menu items and a "Contact Us" button.

Created the `Hero` component to display a prominent title, description, and call-to-action button.

Developed the `CardGrid` component to showcase a grid of cards using the `Card` component.

Added the `InfoText` component to present formatted text alongside an image.

Built the `Footer` component with structured links and copyright information.

Created the `Card` component to display individual cards with a title, description, and footer text.