### PR TITLE
Feature/create global store zustand

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "lucide-react": "^0.525.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
-        "styled-components": "^6.1.19"
+        "styled-components": "^6.1.19",
+        "zustand": "^5.0.6"
       },
       "devDependencies": {
         "@eslint/js": "^9.30.1",
@@ -1342,7 +1343,7 @@
       "version": "19.1.8",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
       "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -3430,6 +3431,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.6.tgz",
+      "integrity": "sha512-ihAqNeUVhe0MAD+X8M5UzqyZ9k3FFZLBTtqo6JLPwV53cbRB/mJwBI0PxcIgqhBBHlEs8G45OTDTMq3gNcLq3A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "styled-components": "^6.1.19",
+        "uuid": "^11.1.0",
         "zustand": "^5.0.6"
       },
       "devDependencies": {
@@ -3289,6 +3290,19 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "styled-components": "^6.1.19",
+    "uuid": "^11.1.0",
     "zustand": "^5.0.6"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "lucide-react": "^0.525.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "styled-components": "^6.1.19"
+    "styled-components": "^6.1.19",
+    "zustand": "^5.0.6"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",

--- a/src/components/cms/page-editor/bem/Inspectable.tsx
+++ b/src/components/cms/page-editor/bem/Inspectable.tsx
@@ -6,6 +6,7 @@ import { useInspectorStore } from '@stores/useInspectorStore'
 import type { InspectorStore } from '@stores/useInspectorStore'
 import type { SelectedComponentProps } from '@stores/useInspectorStore'
 import { getComponentLabel } from '@utils/getComponentLabel'
+import { v4 as uuidv4 } from 'uuid'
 
 interface InspectableProps {
   label?: string
@@ -18,21 +19,21 @@ export const Inspectable: React.FC<InspectableProps> = ({
   children,
   overlayLabelPosition = 'above',
 }) => {
+  const instanceId = React.useMemo(() => uuidv4(), [])
   const computedLabel: string = label ?? getComponentLabel(children)
   const [hovered, setHovered] = useState(false)
 
-  const selectedComponentName = useInspectorStore(
-    (state: InspectorStore) => state.selectedComponentName
+  const selectedComponentId = useInspectorStore(
+    (state: InspectorStore) => state.selectedComponentId
   )
-  const setSelectedComponentName = useInspectorStore(
-    (state: InspectorStore) => state.setSelectedComponentName
+  const setSelectedComponent = useInspectorStore(
+    (state: InspectorStore) => state.setSelectedComponent
   )
 
-  const isSelected = selectedComponentName === computedLabel
+  const isSelected = selectedComponentId === instanceId
   const showOverlay = hovered || isSelected
 
   const handleMouseEnter = () => setHovered(true)
-
   const handleMouseLeave = () => setHovered(false)
 
   const handleSelect = () => {
@@ -40,7 +41,17 @@ export const Inspectable: React.FC<InspectableProps> = ({
     if (React.isValidElement(children)) {
       propsToStore = children.props as SelectedComponentProps
     }
-    setSelectedComponentName(computedLabel, propsToStore)
+    setSelectedComponent(instanceId, computedLabel, propsToStore)
+
+    console.log(`Selected component: ${computedLabel} (ID: ${instanceId})`)
+    console.log('Props:')
+    if (propsToStore && Object.keys(propsToStore).length > 0) {
+      Object.entries(propsToStore).forEach(([key, value]) => {
+        console.log(`  ${key}:`, value)
+      })
+    } else {
+      console.log('  No props found')
+    }
   }
 
   return (

--- a/src/components/cms/page-editor/bem/Inspectable.tsx
+++ b/src/components/cms/page-editor/bem/Inspectable.tsx
@@ -4,6 +4,7 @@ import { InspectorOverlay } from './InspectorOverlay'
 import { Box } from 'grommet'
 import { useInspectorStore } from '@stores/useInspectorStore'
 import type { InspectorStore } from '@stores/useInspectorStore'
+import type { SelectedComponentProps } from '@stores/useInspectorStore'
 import { getComponentLabel } from '@utils/getComponentLabel'
 
 interface InspectableProps {
@@ -20,18 +21,27 @@ export const Inspectable: React.FC<InspectableProps> = ({
   const computedLabel: string = label ?? getComponentLabel(children)
   const [hovered, setHovered] = useState(false)
 
-  const selectedLabel = useInspectorStore(
-    (state: InspectorStore) => state.selectedLabel
+  const inspectedComponentName = useInspectorStore(
+    (state: InspectorStore) => state.inspectedComponentName
   )
-  const setSelectedLabel = useInspectorStore(
-    (state: InspectorStore) => state.setSelectedLabel
+  const setInspectedComponentName = useInspectorStore(
+    (state: InspectorStore) => state.setInspectedComponentName
   )
-  const isSelected = selectedLabel === computedLabel
+
+  const isSelected = inspectedComponentName === computedLabel
   const showOverlay = hovered || isSelected
 
   const handleMouseEnter = () => setHovered(true)
+
   const handleMouseLeave = () => setHovered(false)
-  const handleSelect = () => setSelectedLabel(computedLabel)
+
+  const handleSelect = () => {
+    let propsToStore: SelectedComponentProps = null
+    if (React.isValidElement(children)) {
+      propsToStore = children.props as SelectedComponentProps
+    }
+    setInspectedComponentName(computedLabel, propsToStore ?? undefined)
+  }
 
   return (
     <Box

--- a/src/components/cms/page-editor/bem/Inspectable.tsx
+++ b/src/components/cms/page-editor/bem/Inspectable.tsx
@@ -42,16 +42,6 @@ export const Inspectable: React.FC<InspectableProps> = ({
       propsToStore = children.props as SelectedComponentProps
     }
     setSelectedComponent(instanceId, computedLabel, propsToStore)
-
-    console.log(`Selected component: ${computedLabel} (ID: ${instanceId})`)
-    console.log('Props:')
-    if (propsToStore && Object.keys(propsToStore).length > 0) {
-      Object.entries(propsToStore).forEach(([key, value]) => {
-        console.log(`  ${key}:`, value)
-      })
-    } else {
-      console.log('  No props found')
-    }
   }
 
   return (

--- a/src/components/cms/page-editor/bem/Inspectable.tsx
+++ b/src/components/cms/page-editor/bem/Inspectable.tsx
@@ -21,14 +21,14 @@ export const Inspectable: React.FC<InspectableProps> = ({
   const computedLabel: string = label ?? getComponentLabel(children)
   const [hovered, setHovered] = useState(false)
 
-  const inspectedComponentName = useInspectorStore(
-    (state: InspectorStore) => state.inspectedComponentName
+  const selectedComponentName = useInspectorStore(
+    (state: InspectorStore) => state.selectedComponentName
   )
-  const setInspectedComponentName = useInspectorStore(
-    (state: InspectorStore) => state.setInspectedComponentName
+  const setSelectedComponentName = useInspectorStore(
+    (state: InspectorStore) => state.setSelectedComponentName
   )
 
-  const isSelected = inspectedComponentName === computedLabel
+  const isSelected = selectedComponentName === computedLabel
   const showOverlay = hovered || isSelected
 
   const handleMouseEnter = () => setHovered(true)
@@ -40,7 +40,7 @@ export const Inspectable: React.FC<InspectableProps> = ({
     if (React.isValidElement(children)) {
       propsToStore = children.props as SelectedComponentProps
     }
-    setInspectedComponentName(computedLabel, propsToStore ?? undefined)
+    setSelectedComponentName(computedLabel, propsToStore ?? undefined)
   }
 
   return (

--- a/src/components/cms/page-editor/bem/Inspectable.tsx
+++ b/src/components/cms/page-editor/bem/Inspectable.tsx
@@ -40,7 +40,7 @@ export const Inspectable: React.FC<InspectableProps> = ({
     if (React.isValidElement(children)) {
       propsToStore = children.props as SelectedComponentProps
     }
-    setSelectedComponentName(computedLabel, propsToStore ?? undefined)
+    setSelectedComponentName(computedLabel, propsToStore)
   }
 
   return (
@@ -50,7 +50,7 @@ export const Inspectable: React.FC<InspectableProps> = ({
       width="100%"
     >
       <InspectorOverlay
-        label={computedLabel || ''}
+        label={computedLabel}
         showOverlay={showOverlay}
         isSelected={isSelected}
         onSelect={handleSelect}

--- a/src/components/cms/page-editor/bem/Inspectable.tsx
+++ b/src/components/cms/page-editor/bem/Inspectable.tsx
@@ -2,9 +2,12 @@ import React, { useState } from 'react'
 import type { ReactNode } from 'react'
 import { InspectorOverlay } from './InspectorOverlay'
 import { Box } from 'grommet'
+import { useInspectorStore } from '@stores/useInspectorStore'
+import type { InspectorStore } from '@stores/useInspectorStore'
+import { getComponentLabel } from '@utils/getComponentLabel'
 
 interface InspectableProps {
-  label: string
+  label?: string
   children: ReactNode
   overlayLabelPosition?: 'above' | 'below'
 }
@@ -14,14 +17,21 @@ export const Inspectable: React.FC<InspectableProps> = ({
   children,
   overlayLabelPosition = 'above',
 }) => {
-  const [selected, setSelected] = useState(false)
+  const computedLabel: string = label ?? getComponentLabel(children)
   const [hovered, setHovered] = useState(false)
 
-  const showOverlay = hovered || selected
+  const selectedLabel = useInspectorStore(
+    (state: InspectorStore) => state.selectedLabel
+  )
+  const setSelectedLabel = useInspectorStore(
+    (state: InspectorStore) => state.setSelectedLabel
+  )
+  const isSelected = selectedLabel === computedLabel
+  const showOverlay = hovered || isSelected
 
   const handleMouseEnter = () => setHovered(true)
   const handleMouseLeave = () => setHovered(false)
-  const handleSelect = () => setSelected((prev) => !prev)
+  const handleSelect = () => setSelectedLabel(computedLabel)
 
   return (
     <Box
@@ -30,9 +40,9 @@ export const Inspectable: React.FC<InspectableProps> = ({
       width="100%"
     >
       <InspectorOverlay
-        label={label}
+        label={computedLabel || ''}
         showOverlay={showOverlay}
-        isSelected={selected}
+        isSelected={isSelected}
         onSelect={handleSelect}
         overlayLabelPosition={overlayLabelPosition}
       >

--- a/src/components/cms/page-editor/canvas/PageCanvas.tsx
+++ b/src/components/cms/page-editor/canvas/PageCanvas.tsx
@@ -8,11 +8,11 @@ import { Inspectable } from '../bem/Inspectable'
 
 const PageCanvas = () => {
   const sections = [
-    { label: 'nav__section', component: <Nav /> },
-    { label: 'hero__section', component: <Hero /> },
-    { label: 'card-grid__section', component: <CardGrid /> },
-    { label: 'info-text__section', component: <InfoText /> },
-    { label: 'footer__section', component: <Footer /> },
+    { component: <Nav /> },
+    { component: <Hero /> },
+    { component: <CardGrid /> },
+    { component: <InfoText /> },
+    { component: <Footer /> },
   ]
 
   return (
@@ -22,10 +22,9 @@ const PageCanvas = () => {
       background="white"
       overflow={{ vertical: 'auto', horizontal: 'hidden' }}
     >
-      {sections.map(({ label, component }, idx) => (
+      {sections.map(({ component }, idx) => (
         <Inspectable
-          key={label}
-          label={label}
+          key={idx}
           overlayLabelPosition={idx === 0 ? 'below' : 'above'}
         >
           {component}

--- a/src/components/cms/page-editor/canvas/PageCanvas.tsx
+++ b/src/components/cms/page-editor/canvas/PageCanvas.tsx
@@ -1,3 +1,5 @@
+import { v4 as uuidv4 } from 'uuid'
+
 import CardGrid from '@components/site/CardGrid'
 import Footer from '@components/site/Footer'
 import Hero from '@components/site/Hero'
@@ -24,7 +26,7 @@ const PageCanvas = () => {
     >
       {sections.map(({ component }, idx) => (
         <Inspectable
-          key={idx}
+          key={uuidv4()}
           overlayLabelPosition={idx === 0 ? 'below' : 'above'}
         >
           {component}

--- a/src/components/cms/page-editor/canvas/PageCanvas.tsx
+++ b/src/components/cms/page-editor/canvas/PageCanvas.tsx
@@ -1,5 +1,3 @@
-import { v4 as uuidv4 } from 'uuid'
-
 import CardGrid from '@components/site/CardGrid'
 import Footer from '@components/site/Footer'
 import Hero from '@components/site/Hero'
@@ -26,7 +24,7 @@ const PageCanvas = () => {
     >
       {sections.map(({ component }, idx) => (
         <Inspectable
-          key={uuidv4()}
+          key={idx}
           overlayLabelPosition={idx === 0 ? 'below' : 'above'}
         >
           {component}

--- a/src/components/cms/page-editor/panels/editor/PanelPageEditor.tsx
+++ b/src/components/cms/page-editor/panels/editor/PanelPageEditor.tsx
@@ -1,4 +1,4 @@
-import { FormField, Heading, Text, TextArea, TextInput } from 'grommet'
+import { Box, FormField, Heading, Text, TextArea, TextInput } from 'grommet'
 import PanelBox from '@components/cms/ui/panel/PanelBox'
 import PanelBoxCollapsable from '@components/cms/ui/panel/PanelBoxCollapsible'
 import {
@@ -9,17 +9,28 @@ import {
 } from '@components/cms/ui/panel/PanelTabs/index'
 import PanelBoxScroll from '@components/cms/ui/panel/PanelBoxScroll'
 import PanelWrapper from '@components/cms/ui/panel/PanelWrapper'
-import { Eclipse, Pencil, Settings } from 'lucide-react'
+import { Eclipse, Layers, Pencil, Settings } from 'lucide-react'
+import { useInspectorStore } from '@stores/useInspectorStore'
 
 const PanelPageEditor = () => {
+  const selectedComponentName = useInspectorStore(
+    (state) => state.selectedComponentName
+  )
+
   return (
     <PanelWrapper borderSide="left">
       <PanelBox>
-        <Heading level={5} margin="none">
-          Component Editor
-        </Heading>
+        <Box direction="row" gap="xsmall" align="center">
+          <Layers size={16} />
+          <Heading level={5} margin="none">
+            {selectedComponentName
+              ? selectedComponentName
+              : 'Select a component'}
+          </Heading>
+        </Box>
+
         <Text size="xsmall" color="dark-4">
-          Edit the properties of the selected component
+          Edit the properties of the {selectedComponentName} component
         </Text>
       </PanelBox>
 

--- a/src/stores/useInspectorStore.ts
+++ b/src/stores/useInspectorStore.ts
@@ -3,17 +3,20 @@ import { create } from 'zustand'
 export type SelectedComponentProps = { [key: string]: unknown } | null
 
 export interface InspectorStore {
-  inspectedComponentName: string | null
-  selectedProps: SelectedComponentProps
-  setInspectedComponentName: (
+  selectedComponentName: string | null
+  selectedComponentProps: SelectedComponentProps
+  setSelectedComponentName: (
     label: string | null,
     props?: SelectedComponentProps
   ) => void
 }
 
 export const useInspectorStore = create<InspectorStore>((set) => ({
-  inspectedComponentName: null,
-  selectedProps: null,
-  setInspectedComponentName: (label, props) =>
-    set({ inspectedComponentName: label, selectedProps: props ?? null }),
+  selectedComponentName: null,
+  selectedComponentProps: null,
+  setSelectedComponentName: (label, props) =>
+    set({
+      selectedComponentName: label,
+      selectedComponentProps: props ?? null,
+    }),
 }))

--- a/src/stores/useInspectorStore.ts
+++ b/src/stores/useInspectorStore.ts
@@ -1,0 +1,11 @@
+import { create } from 'zustand'
+
+export interface InspectorStore {
+  selectedLabel: string | null
+  setSelectedLabel: (label: string | null) => void
+}
+
+export const useInspectorStore = create<InspectorStore>((set) => ({
+  selectedLabel: null,
+  setSelectedLabel: (label) => set({ selectedLabel: label }),
+}))

--- a/src/stores/useInspectorStore.ts
+++ b/src/stores/useInspectorStore.ts
@@ -1,11 +1,19 @@
 import { create } from 'zustand'
 
+export type SelectedComponentProps = { [key: string]: unknown } | null
+
 export interface InspectorStore {
-  selectedLabel: string | null
-  setSelectedLabel: (label: string | null) => void
+  inspectedComponentName: string | null
+  selectedProps: SelectedComponentProps
+  setInspectedComponentName: (
+    label: string | null,
+    props?: SelectedComponentProps
+  ) => void
 }
 
 export const useInspectorStore = create<InspectorStore>((set) => ({
-  selectedLabel: null,
-  setSelectedLabel: (label) => set({ selectedLabel: label }),
+  inspectedComponentName: null,
+  selectedProps: null,
+  setInspectedComponentName: (label, props) =>
+    set({ inspectedComponentName: label, selectedProps: props ?? null }),
 }))

--- a/src/stores/useInspectorStore.ts
+++ b/src/stores/useInspectorStore.ts
@@ -3,20 +3,24 @@ import { create } from 'zustand'
 export type SelectedComponentProps = { [key: string]: unknown } | null
 
 export interface InspectorStore {
+  selectedComponentId: string | null
   selectedComponentName: string | null
   selectedComponentProps: SelectedComponentProps
-  setSelectedComponentName: (
-    label: string | null,
+  setSelectedComponent: (
+    id: string | null,
+    name: string | null,
     props?: SelectedComponentProps
   ) => void
 }
 
 export const useInspectorStore = create<InspectorStore>((set) => ({
+  selectedComponentId: null,
   selectedComponentName: null,
   selectedComponentProps: null,
-  setSelectedComponentName: (label, props) =>
+  setSelectedComponent: (id, name, props) =>
     set({
-      selectedComponentName: label,
+      selectedComponentId: id,
+      selectedComponentName: name,
       selectedComponentProps: props ?? null,
     }),
 }))

--- a/src/utils/getComponentLabel.ts
+++ b/src/utils/getComponentLabel.ts
@@ -1,0 +1,12 @@
+import React from 'react'
+
+export function getComponentLabel(
+  children: React.ReactNode,
+  fallback = 'Component'
+): string {
+  if (React.isValidElement(children)) {
+    const type = children.type
+    if (typeof type === 'function' && type.name) return type.name
+  }
+  return fallback
+}

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -26,6 +26,8 @@
     "baseUrl": "./",
     "paths": {
       "@components/*": ["src/components/*"],
+      "@stores/*": ["src/stores/*"],
+      "@services/*": ["src/services/*"],
       "@hooks/*": ["src/hooks/*"],
       "@utils/*": ["src/utils/*"],
       "@contexts/*": ["src/contexts/*"],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,8 @@ export default defineConfig({
   resolve: {
     alias: {
       '@components': '/src/components',
+      '@stores': '/src/stores',
+      '@services': '/src/services',
       '@hooks': '/src/hooks',
       '@utils': '/src/utils',
       '@contexts': '/src/contexts',


### PR DESCRIPTION
<img width="1593" height="645" alt="image" src="https://github.com/user-attachments/assets/d2e8aa9f-d384-4902-9a12-e6b00483fea0" />

This pull request introduces a new state management system using `zustand` and implements a feature to track and edit selected components in the CMS page editor. It also includes utility functions, updates to component props, and configuration changes to support the new functionality.

### State Management and Store Integration:
* Added a `zustand` store in `src/stores/useInspectorStore.ts` to manage the state of the selected component, including its name and props.
* Updated `src/components/cms/page-editor/bem/Inspectable.tsx` to integrate the `zustand` store, replacing local state with global state for tracking selected components.

### Component Enhancements:
* Modified the `Inspectable` component to compute labels dynamically using a new utility function `getComponentLabel` in `src/utils/getComponentLabel.ts`. 
* Updated `PageCanvas` to remove hardcoded labels, relying on dynamic label computation instead. 

### UI Updates:
* Enhanced the `PanelPageEditor` to display the name of the selected component using the `zustand` store, improving the user interface for editing component properties.

### Configuration Changes:
* Added path aliases for `@stores` and `@services` in `tsconfig.app.json` and `vite.config.ts` for better project organization and easier imports. 

### Dependency Updates:
* Added `zustand` to `package.json` as a new dependency for state management.