### PR TITLE
Feature/add section drag and drop on canvas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/modifiers": "^9.0.0",
         "@dnd-kit/sortable": "^10.0.0",
         "grommet": "^2.47.0",
         "grommet-icons": "^4.14.0",
@@ -337,6 +338,20 @@
       "peerDependencies": {
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/modifiers": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/modifiers/-/modifiers-9.0.0.tgz",
+      "integrity": "sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@dnd-kit/sortable": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "site-builder",
       "version": "0.0.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
         "grommet": "^2.47.0",
         "grommet-icons": "^4.14.0",
         "grommet-theme-hpe": "^6.4.2",
@@ -308,6 +310,59 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emotion/is-prop-valid": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/modifiers": "^9.0.0",
     "@dnd-kit/sortable": "^10.0.0",
     "grommet": "^2.47.0",
     "grommet-icons": "^4.14.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
     "grommet": "^2.47.0",
     "grommet-icons": "^4.14.0",
     "grommet-theme-hpe": "^6.4.2",

--- a/src/components/cms/page-editor/canvas/PageCanvas.tsx
+++ b/src/components/cms/page-editor/canvas/PageCanvas.tsx
@@ -2,9 +2,51 @@ import { Box } from 'grommet'
 import { Inspectable } from '../bem/Inspectable'
 import { usePageStore } from '@stores/usePageStore'
 import { sectionMap } from '@lib/sectionMap'
+import {
+  DndContext,
+  closestCenter,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core'
+import {
+  SortableContext,
+  arrayMove,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable'
+import SortableSection from './SortableSection'
+
+function renderSection(
+  id: string,
+  name: string,
+  props: Record<string, unknown>,
+  idx: number
+) {
+  if (!(name in sectionMap)) return null
+  const section = sectionMap[name as keyof typeof sectionMap]
+  if (!section || !section.component) return null
+  const Component = section.component
+
+  return (
+    <SortableSection id={id} key={id}>
+      <Inspectable
+        id={id}
+        name={name}
+        overlayLabelPosition={idx === 0 ? 'below' : 'above'}
+      >
+        <Component {...props} />
+      </Inspectable>
+    </SortableSection>
+  )
+}
 
 const PageCanvas = () => {
   const sections = usePageStore((state) => state.sections)
+  const setSections = usePageStore((state) => state.setSections)
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } })
+  )
+  const sectionIds = sections.map((s) => s.id)
 
   return (
     <Box
@@ -13,25 +55,28 @@ const PageCanvas = () => {
       background="white"
       overflow={{ vertical: 'auto', horizontal: 'hidden' }}
     >
-      {sections.map(({ id, name, props }, idx) => {
-        if (!(name in sectionMap)) return null
-
-        const section = sectionMap[name as keyof typeof sectionMap]
-
-        if (!section || !section.component) return null
-        const Component = section.component
-
-        return (
-          <Inspectable
-            id={id}
-            key={idx}
-            name={name}
-            overlayLabelPosition={idx === 0 ? 'below' : 'above'}
-          >
-            <Component {...props} />
-          </Inspectable>
-        )
-      })}
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragStart={() => {}}
+        onDragEnd={({ active, over }) => {
+          if (active.id !== over?.id) {
+            const oldIndex = sections.findIndex((s) => s.id === active.id)
+            const newIndex = sections.findIndex((s) => s.id === over?.id)
+            setSections(arrayMove(sections, oldIndex, newIndex))
+          }
+        }}
+        onDragCancel={() => {}}
+      >
+        <SortableContext
+          items={sectionIds}
+          strategy={verticalListSortingStrategy}
+        >
+          {sections.map((section, idx) =>
+            renderSection(section.id, section.name, section.props, idx)
+          )}
+        </SortableContext>
+      </DndContext>
     </Box>
   )
 }

--- a/src/components/cms/page-editor/canvas/PageCanvas.tsx
+++ b/src/components/cms/page-editor/canvas/PageCanvas.tsx
@@ -28,13 +28,8 @@ const PageCanvas = () => {
     (event: DragEndEvent) => {
       const { active, over } = event
       if (over && active.id !== over.id) {
-        const currentSections = usePageStore.getState().sections
-        const oldIndex = currentSections.findIndex(
-          (s) => s.id === String(active.id)
-        )
-        const newIndex = currentSections.findIndex(
-          (s) => s.id === String(over.id)
-        )
+        const oldIndex = sections.findIndex((s) => s.id === String(active.id))
+        const newIndex = sections.findIndex((s) => s.id === String(over.id))
 
         if (oldIndex === -1 || newIndex === -1) {
           console.error(
@@ -43,10 +38,10 @@ const PageCanvas = () => {
           return
         }
 
-        setSections(arrayMove(currentSections, oldIndex, newIndex))
+        setSections(arrayMove(sections, oldIndex, newIndex))
       }
     },
-    [setSections]
+    [sections, setSections]
   )
 
   return (

--- a/src/components/cms/page-editor/canvas/PageCanvas.tsx
+++ b/src/components/cms/page-editor/canvas/PageCanvas.tsx
@@ -36,7 +36,6 @@ const PageCanvas = () => {
           if (over && active.id !== over.id) {
             const oldIndex = sections.findIndex((s) => s.id === active.id)
             const newIndex = sections.findIndex((s) => s.id === over.id)
-            setSections(arrayMove(sections, oldIndex, newIndex))
 
             if (oldIndex === -1 || newIndex === -1) {
               console.error(
@@ -44,6 +43,8 @@ const PageCanvas = () => {
               )
               return
             }
+
+            setSections(arrayMove(sections, oldIndex, newIndex))
           }
         }}
       >

--- a/src/components/cms/page-editor/canvas/PageCanvas.tsx
+++ b/src/components/cms/page-editor/canvas/PageCanvas.tsx
@@ -12,7 +12,6 @@ import {
   arrayMove,
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable'
-import { restrictToParentElement } from '@dnd-kit/modifiers'
 import PageSectionRenderer from './PageSectionRenderer'
 
 const PageCanvas = () => {
@@ -33,7 +32,6 @@ const PageCanvas = () => {
       <DndContext
         sensors={sensors}
         collisionDetection={closestCenter}
-        modifiers={[restrictToParentElement]}
         onDragStart={() => {}}
         onDragEnd={({ active, over }) => {
           if (active.id !== over?.id) {

--- a/src/components/cms/page-editor/canvas/PageCanvas.tsx
+++ b/src/components/cms/page-editor/canvas/PageCanvas.tsx
@@ -39,7 +39,7 @@ const PageCanvas = () => {
 
             if (oldIndex === -1 || newIndex === -1) {
               console.error(
-                'Invalid section ID detected during drag-and-drop operation.'
+                `Invalid section ID detected during drag-and-drop operation. Active: ${active.id}, Over: ${over.id}`
               )
               return
             }

--- a/src/components/cms/page-editor/canvas/PageCanvas.tsx
+++ b/src/components/cms/page-editor/canvas/PageCanvas.tsx
@@ -1,7 +1,5 @@
 import { Box } from 'grommet'
-import { Inspectable } from '../bem/Inspectable'
 import { usePageStore } from '@stores/usePageStore'
-import { sectionMap } from '@lib/sectionMap'
 import {
   DndContext,
   closestCenter,
@@ -14,31 +12,8 @@ import {
   arrayMove,
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable'
-import SortableSection from './SortableSection'
-
-function renderSection(
-  id: string,
-  name: string,
-  props: Record<string, unknown>,
-  idx: number
-) {
-  if (!(name in sectionMap)) return null
-  const section = sectionMap[name as keyof typeof sectionMap]
-  if (!section || !section.component) return null
-  const Component = section.component
-
-  return (
-    <SortableSection id={id} key={id}>
-      <Inspectable
-        id={id}
-        name={name}
-        overlayLabelPosition={idx === 0 ? 'below' : 'above'}
-      >
-        <Component {...props} />
-      </Inspectable>
-    </SortableSection>
-  )
-}
+import { restrictToParentElement } from '@dnd-kit/modifiers'
+import PageSectionRenderer from './PageSectionRenderer'
 
 const PageCanvas = () => {
   const sections = usePageStore((state) => state.sections)
@@ -58,6 +33,7 @@ const PageCanvas = () => {
       <DndContext
         sensors={sensors}
         collisionDetection={closestCenter}
+        modifiers={[restrictToParentElement]}
         onDragStart={() => {}}
         onDragEnd={({ active, over }) => {
           if (active.id !== over?.id) {
@@ -72,9 +48,15 @@ const PageCanvas = () => {
           items={sectionIds}
           strategy={verticalListSortingStrategy}
         >
-          {sections.map((section, idx) =>
-            renderSection(section.id, section.name, section.props, idx)
-          )}
+          {sections.map((section, idx) => (
+            <PageSectionRenderer
+              key={section.id}
+              id={section.id}
+              name={section.name}
+              props={section.props}
+              idx={idx}
+            />
+          ))}
         </SortableContext>
       </DndContext>
     </Box>

--- a/src/components/cms/page-editor/canvas/PageCanvas.tsx
+++ b/src/components/cms/page-editor/canvas/PageCanvas.tsx
@@ -33,10 +33,17 @@ const PageCanvas = () => {
         sensors={sensors}
         collisionDetection={closestCenter}
         onDragEnd={({ active, over }) => {
-          if (active.id !== over?.id) {
+          if (over && active.id !== over.id) {
             const oldIndex = sections.findIndex((s) => s.id === active.id)
-            const newIndex = sections.findIndex((s) => s.id === over?.id)
+            const newIndex = sections.findIndex((s) => s.id === over.id)
             setSections(arrayMove(sections, oldIndex, newIndex))
+
+            if (oldIndex === -1 || newIndex === -1) {
+              console.error(
+                'Invalid section ID detected during drag-and-drop operation.'
+              )
+              return
+            }
           }
         }}
       >

--- a/src/components/cms/page-editor/canvas/PageCanvas.tsx
+++ b/src/components/cms/page-editor/canvas/PageCanvas.tsx
@@ -32,7 +32,6 @@ const PageCanvas = () => {
       <DndContext
         sensors={sensors}
         collisionDetection={closestCenter}
-        onDragStart={() => {}}
         onDragEnd={({ active, over }) => {
           if (active.id !== over?.id) {
             const oldIndex = sections.findIndex((s) => s.id === active.id)
@@ -40,7 +39,6 @@ const PageCanvas = () => {
             setSections(arrayMove(sections, oldIndex, newIndex))
           }
         }}
-        onDragCancel={() => {}}
       >
         <SortableContext
           items={sectionIds}

--- a/src/components/cms/page-editor/canvas/PageSectionRenderer.tsx
+++ b/src/components/cms/page-editor/canvas/PageSectionRenderer.tsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import { Inspectable } from '../bem/Inspectable'
+import { sectionMap } from '@lib/sectionMap'
+import SortableSection from './SortableSection'
+
+type PageSectionRendererProps = {
+  id: string
+  name: string
+  props: Record<string, unknown>
+  idx: number
+}
+
+const PageSectionRenderer: React.FC<PageSectionRendererProps> = ({
+  id,
+  name,
+  props,
+  idx,
+}) => {
+  if (!(name in sectionMap)) return null
+  const section = sectionMap[name as keyof typeof sectionMap]
+  if (!section || !section.component) return null
+  const Component = section.component
+
+  return (
+    <SortableSection id={id} key={id}>
+      <Inspectable
+        id={id}
+        name={name}
+        overlayLabelPosition={idx === 0 ? 'below' : 'above'}
+      >
+        <Component {...props} />
+      </Inspectable>
+    </SortableSection>
+  )
+}
+
+export default PageSectionRenderer

--- a/src/components/cms/page-editor/canvas/SortableSection.tsx
+++ b/src/components/cms/page-editor/canvas/SortableSection.tsx
@@ -46,7 +46,6 @@ const SortableSection: React.FC<Props> = ({ id, children }) => {
     position: isDragging ? 'relative' : undefined,
     minHeight: DRAGGING_MIN_HEIGHT,
     background: isDragging ? DRAGGING_BG : isOver ? OVER_BG : undefined,
-    pointerEvents: isDragging ? 'none' : undefined,
   }
 
   return (

--- a/src/components/cms/page-editor/canvas/SortableSection.tsx
+++ b/src/components/cms/page-editor/canvas/SortableSection.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useRef, useMemo } from 'react'
 import { useSortable } from '@dnd-kit/sortable'
 import { usePageStore } from '@stores/usePageStore'
 import {
@@ -26,27 +26,32 @@ const SortableSection: React.FC<Props> = ({ id, children }) => {
   } = useSortable({ id })
 
   const selectSection = usePageStore((state) => state.selectSection)
+  const wasDragging = useRef(false)
 
   useEffect(() => {
-    if (isDragging) {
+    if (!wasDragging.current && isDragging) {
       selectSection(id)
     }
+    wasDragging.current = isDragging
   }, [isDragging, id, selectSection])
 
-  const style: React.CSSProperties = {
-    transform: transform
-      ? `translate3d(${transform.x}px, ${transform.y}px, 0)`
-      : undefined,
-    transition: transition,
-    touchAction: 'none',
-    width: '100%',
-    boxSizing: 'border-box',
-    cursor: isDragging ? 'grabbing' : 'grab',
-    zIndex: isDragging ? DRAGGING_Z_INDEX : NORMAL_Z_INDEX,
-    position: 'relative',
-    minHeight: isDragging ? DRAGGING_MIN_HEIGHT : undefined,
-    background: isDragging ? DRAGGING_BG : isOver ? OVER_BG : undefined,
-  }
+  const style = useMemo<React.CSSProperties>(
+    () => ({
+      transform: transform
+        ? `translate3d(${transform.x}px, ${transform.y}px, 0)`
+        : undefined,
+      transition: transition,
+      touchAction: 'none',
+      width: '100%',
+      boxSizing: 'border-box',
+      cursor: isDragging ? 'grabbing' : 'grab',
+      zIndex: isDragging ? DRAGGING_Z_INDEX : NORMAL_Z_INDEX,
+      position: 'relative',
+      minHeight: isDragging ? DRAGGING_MIN_HEIGHT : undefined,
+      background: isDragging ? DRAGGING_BG : isOver ? OVER_BG : undefined,
+    }),
+    [transform, transition, isDragging, isOver]
+  )
 
   return (
     <div ref={setNodeRef} style={style} {...attributes} {...listeners}>

--- a/src/components/cms/page-editor/canvas/SortableSection.tsx
+++ b/src/components/cms/page-editor/canvas/SortableSection.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { useSortable } from '@dnd-kit/sortable'
-import { CSS } from '@dnd-kit/utilities'
 
 type Props = {
   id: string
@@ -18,15 +17,16 @@ const SortableSection: React.FC<Props> = ({ id, children }) => {
   } = useSortable({ id })
 
   const style: React.CSSProperties = {
-    transform: CSS.Transform.toString(transform),
+    transform: transform
+      ? `translate3d(${transform.x}px, ${transform.y}px, 0)`
+      : undefined,
     transition,
     touchAction: 'none',
     width: '100%',
     boxSizing: 'border-box',
     cursor: isDragging ? 'grabbing' : 'grab',
-    zIndex: isDragging ? 2 : 1,
+    zIndex: isDragging ? 1000 : 1,
     minHeight: 40,
-    background: isDragging ? '#f0f0f0' : undefined,
   }
   return (
     <div ref={setNodeRef} style={style} {...attributes} {...listeners}>

--- a/src/components/cms/page-editor/canvas/SortableSection.tsx
+++ b/src/components/cms/page-editor/canvas/SortableSection.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useMemo, useCallback } from 'react'
+import React, { useEffect, useMemo, useCallback } from 'react'
 import { useSortable } from '@dnd-kit/sortable'
 import { usePageStore } from '@stores/usePageStore'
 import {
@@ -31,13 +31,11 @@ const SortableSection: React.FC<Props> = ({ id, children }) => {
     []
   )
   const selectSection = usePageStore(selectSectionSelector)
-  const wasDragging = useRef(false)
 
   useEffect(() => {
-    if (!wasDragging.current && isDragging) {
+    if (isDragging) {
       selectSection(id)
     }
-    wasDragging.current = isDragging
   }, [isDragging, id, selectSection])
 
   const style = useMemo<React.CSSProperties>(

--- a/src/components/cms/page-editor/canvas/SortableSection.tsx
+++ b/src/components/cms/page-editor/canvas/SortableSection.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useCallback } from 'react'
+import React, { useEffect, useMemo } from 'react'
 import { useSortable } from '@dnd-kit/sortable'
 import { usePageStore } from '@stores/usePageStore'
 import {
@@ -15,6 +15,8 @@ type Props = {
   children: React.ReactNode
 }
 
+const selectSectionSelector = (state: PageStore) => state.selectSection
+
 const SortableSection: React.FC<Props> = ({ id, children }) => {
   const {
     attributes,
@@ -26,10 +28,6 @@ const SortableSection: React.FC<Props> = ({ id, children }) => {
     isOver,
   } = useSortable({ id })
 
-  const selectSectionSelector = useCallback(
-    (state: PageStore) => state.selectSection,
-    []
-  )
   const selectSection = usePageStore(selectSectionSelector)
 
   useEffect(() => {

--- a/src/components/cms/page-editor/canvas/SortableSection.tsx
+++ b/src/components/cms/page-editor/canvas/SortableSection.tsx
@@ -43,8 +43,8 @@ const SortableSection: React.FC<Props> = ({ id, children }) => {
     boxSizing: 'border-box',
     cursor: isDragging ? 'grabbing' : 'grab',
     zIndex: isDragging ? DRAGGING_Z_INDEX : NORMAL_Z_INDEX,
-    position: isDragging ? 'relative' : undefined,
-    minHeight: DRAGGING_MIN_HEIGHT,
+    position: 'relative',
+    minHeight: isDragging ? DRAGGING_MIN_HEIGHT : undefined,
     background: isDragging ? DRAGGING_BG : isOver ? OVER_BG : undefined,
   }
 

--- a/src/components/cms/page-editor/canvas/SortableSection.tsx
+++ b/src/components/cms/page-editor/canvas/SortableSection.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import { useSortable } from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+
+type Props = {
+  id: string
+  children: React.ReactNode
+}
+
+const SortableSection: React.FC<Props> = ({ id, children }) => {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id })
+
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    touchAction: 'none',
+    width: '100%',
+    boxSizing: 'border-box',
+    cursor: isDragging ? 'grabbing' : 'grab',
+    zIndex: isDragging ? 2 : 1,
+    minHeight: 40,
+    background: isDragging ? '#f0f0f0' : undefined,
+  }
+  return (
+    <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
+      {children}
+    </div>
+  )
+}
+
+export default SortableSection

--- a/src/components/cms/page-editor/canvas/SortableSection.tsx
+++ b/src/components/cms/page-editor/canvas/SortableSection.tsx
@@ -1,6 +1,13 @@
 import React, { useEffect } from 'react'
 import { useSortable } from '@dnd-kit/sortable'
 import { usePageStore } from '@stores/usePageStore'
+import {
+  DRAGGING_Z_INDEX,
+  NORMAL_Z_INDEX,
+  DRAGGING_MIN_HEIGHT,
+  DRAGGING_BG,
+  OVER_BG,
+} from './constants'
 
 type Props = {
   id: string
@@ -35,10 +42,10 @@ const SortableSection: React.FC<Props> = ({ id, children }) => {
     width: '100%',
     boxSizing: 'border-box',
     cursor: isDragging ? 'grabbing' : 'grab',
-    zIndex: isDragging ? 9999 : 1,
+    zIndex: isDragging ? DRAGGING_Z_INDEX : NORMAL_Z_INDEX,
     position: isDragging ? 'relative' : undefined,
-    minHeight: 40,
-    background: isDragging ? '#f0f0f0' : isOver ? '#e0e7ff' : undefined,
+    minHeight: DRAGGING_MIN_HEIGHT,
+    background: isDragging ? DRAGGING_BG : isOver ? OVER_BG : undefined,
     pointerEvents: isDragging ? 'none' : undefined,
   }
 

--- a/src/components/cms/page-editor/canvas/SortableSection.tsx
+++ b/src/components/cms/page-editor/canvas/SortableSection.tsx
@@ -1,5 +1,6 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { useSortable } from '@dnd-kit/sortable'
+import { usePageStore } from '@stores/usePageStore'
 
 type Props = {
   id: string
@@ -14,20 +15,33 @@ const SortableSection: React.FC<Props> = ({ id, children }) => {
     transform,
     transition,
     isDragging,
+    isOver,
   } = useSortable({ id })
+
+  const selectSection = usePageStore((state) => state.selectSection)
+
+  useEffect(() => {
+    if (isDragging) {
+      selectSection(id)
+    }
+  }, [isDragging, id, selectSection])
 
   const style: React.CSSProperties = {
     transform: transform
       ? `translate3d(${transform.x}px, ${transform.y}px, 0)`
       : undefined,
-    transition,
+    transition: transition,
     touchAction: 'none',
     width: '100%',
     boxSizing: 'border-box',
     cursor: isDragging ? 'grabbing' : 'grab',
-    zIndex: isDragging ? 1000 : 1,
+    zIndex: isDragging ? 9999 : 1,
+    position: isDragging ? 'relative' : undefined,
     minHeight: 40,
+    background: isDragging ? '#f0f0f0' : isOver ? '#e0e7ff' : undefined,
+    pointerEvents: isDragging ? 'none' : undefined,
   }
+
   return (
     <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
       {children}

--- a/src/components/cms/page-editor/canvas/SortableSection.tsx
+++ b/src/components/cms/page-editor/canvas/SortableSection.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useMemo } from 'react'
+import React, { useEffect, useRef, useMemo, useCallback } from 'react'
 import { useSortable } from '@dnd-kit/sortable'
 import { usePageStore } from '@stores/usePageStore'
 import {
@@ -8,6 +8,7 @@ import {
   DRAGGING_BG,
   OVER_BG,
 } from './constants'
+import type { PageStore } from '@src/types'
 
 type Props = {
   id: string
@@ -25,7 +26,11 @@ const SortableSection: React.FC<Props> = ({ id, children }) => {
     isOver,
   } = useSortable({ id })
 
-  const selectSection = usePageStore((state) => state.selectSection)
+  const selectSectionSelector = useCallback(
+    (state: PageStore) => state.selectSection,
+    []
+  )
+  const selectSection = usePageStore(selectSectionSelector)
   const wasDragging = useRef(false)
 
   useEffect(() => {

--- a/src/components/cms/page-editor/canvas/constants.ts
+++ b/src/components/cms/page-editor/canvas/constants.ts
@@ -1,0 +1,5 @@
+export const DRAGGING_Z_INDEX = 9999
+export const NORMAL_Z_INDEX = 1
+export const DRAGGING_MIN_HEIGHT = 40
+export const DRAGGING_BG = '#f0f0f0'
+export const OVER_BG = '#e0e7ff'


### PR DESCRIPTION
This pull request introduces drag-and-drop functionality to the page editor's canvas, enabling users to reorder sections visually. The changes include integrating the `@dnd-kit` library, refactoring the section rendering logic, and creating new components to support sortable sections.


https://github.com/user-attachments/assets/23f052c9-67d7-41a1-8e20-d12bcf65b5d6


### Drag-and-Drop Functionality Integration:
* **Added `@dnd-kit` dependencies**: Included `@dnd-kit/core`, `@dnd-kit/modifiers`, and `@dnd-kit/sortable` in `package.json` to enable drag-and-drop capabilities.
* **Implemented `DndContext` and `SortableContext`**: Refactored `PageCanvas` to use `DndContext` for drag-and-drop behavior and `SortableContext` for managing sortable sections. Introduced collision detection and reordering logic using `arrayMove`. 

### Component Refactoring:
* **Created `PageSectionRenderer`**: Extracted section rendering logic from `PageCanvas` into a new component, `PageSectionRenderer`, to improve modularity and readability. This component handles section validation and rendering using `Inspectable` and `SortableSection`.
* **Introduced `SortableSection`**: Added a new component, `SortableSection`, to encapsulate sortable behavior for individual sections. It uses `useSortable` from `@dnd-kit/sortable` to manage drag-and-drop interactions and applies dynamic styles during dragging.

These changes enhance the user experience by providing an intuitive way to rearrange sections within the page editor, while improving code organization and maintainability.